### PR TITLE
feat: implement AI mode configuration and handling for mock/live modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The following variables are required in your `.env.local`:
 | `NEXT_PUBLIC_SUPABASE_URL` | Your Supabase project URL |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Your Supabase anonymous public key |
 | `ANTHROPIC_API_KEY` | Your Anthropic Claude API key (server-side only) |
-| `SCRUMIQ_AI_MODE` | Optional. `mock` (default if unset) = `/api/projects/ai-brief` returns local mock data. `live` = reserved until a real provider is implemented. |
+| `SCRUMIQ_AI_MODE` | Optional. Single switch in `.env.local` (no `NEXT_PUBLIC_*` copy needed). `mock` (default if unset) = mock brief responses and the backlog flow uses **`buildStubBacklogDraftFromInput`** (no API credits). `live` = reserved until live providers and **`POST /api/projects/ai-backlog`** are implemented. The client reads this via **`GET /api/ai-config`**. |
 
 These can be found in:
 - **Supabase** — [supabase.com](https://supabase.com) → your project → Settings → API

--- a/app/api/ai-config/route.ts
+++ b/app/api/ai-config/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import type { ScrumiqAiMode } from "@/lib/projects/ai-mode";
+import { parseScrumiqAiMode } from "@/lib/projects/ai-mode";
+
+/**
+ * Exposes `SCRUMIQ_AI_MODE` to the client without a `NEXT_PUBLIC_*` duplicate.
+ * Safe to call unauthenticated — values are not secrets.
+ */
+export async function GET() {
+  const mode: ScrumiqAiMode = parseScrumiqAiMode(process.env.SCRUMIQ_AI_MODE);
+  return NextResponse.json({ mode });
+}

--- a/app/api/projects/ai-brief/route.ts
+++ b/app/api/projects/ai-brief/route.ts
@@ -1,13 +1,7 @@
 import { NextResponse } from "next/server";
 import type { ProjectAiBriefInput } from "@/lib/projects/ai-brief-types";
 import { buildMockAiBrief } from "@/lib/projects/ai-brief-mock";
-
-function isMockMode(): boolean {
-  const m = process.env.SCRUMIQ_AI_MODE?.toLowerCase().trim();
-  if (m === "live") return false;
-  if (m === "mock") return true;
-  return true;
-}
+import { isMockAiMode } from "@/lib/projects/ai-mode";
 
 function validateBody(body: unknown): body is ProjectAiBriefInput {
   if (!body || typeof body !== "object") return false;
@@ -60,7 +54,7 @@ export async function POST(req: Request) {
     );
   }
 
-  if (isMockMode()) {
+  if (isMockAiMode(process.env.SCRUMIQ_AI_MODE)) {
     await new Promise((r) =>
       setTimeout(r, 650 + Math.floor(Math.random() * 500))
     );

--- a/components/projects/ai-flow/ProjectAiFlowView.tsx
+++ b/components/projects/ai-flow/ProjectAiFlowView.tsx
@@ -26,6 +26,7 @@ import { AiGenerateConfirmModal } from "@/components/projects/ai-flow/AiGenerate
 import { GreenBeamPanel } from "@/components/projects/ai-flow/GreenBeamPanel";
 import { SECONDARY_BTN_CLASS } from "@/components/projects/ai-flow/flow-constants";
 import { cn } from "@/lib/utils";
+import { useAiConfig } from "@/hooks/use-ai-config";
 
 type Phase = "form" | "generating" | "artifact-review" | "error";
 
@@ -86,6 +87,7 @@ export function ProjectAiFlowView({
   projectId,
   projectName,
 }: ProjectAiFlowViewProps) {
+  const aiConfig = useAiConfig();
   const router = useRouter();
   const { projects, updateProject } = useProjectsWorkspace();
   const project = projects.find((p) => p.id === projectId);
@@ -131,6 +133,20 @@ export function ProjectAiFlowView({
     const payload = toPayload(input);
     setPhase("generating");
     setErrorMessage("");
+    if (aiConfig.status !== "ready") {
+      setPhase("error");
+      setErrorMessage(
+        "AI settings aren’t ready yet. Refresh the page and try again."
+      );
+      return;
+    }
+    if (aiConfig.mode === "live") {
+      setPhase("error");
+      setErrorMessage(
+        "Live backlog generation isn’t implemented yet. Set SCRUMIQ_AI_MODE=mock in .env.local (or leave it unset) to use mock data without API credits."
+      );
+      return;
+    }
     try {
       await delayGenerationMs();
       const d = buildStubBacklogDraftFromInput(payload);
@@ -141,7 +157,7 @@ export function ProjectAiFlowView({
       setPhase("error");
       setErrorMessage("Couldn’t generate work items. Try again.");
     }
-  }, [input, projectId]);
+  }, [input, projectId, aiConfig]);
 
   const handleSubmitForm = (e: React.FormEvent) => {
     e.preventDefault();
@@ -211,6 +227,50 @@ export function ProjectAiFlowView({
         onCancel={() => setGenerateConfirmOpen(false)}
         onConfirm={handleConfirmGenerate}
       />
+      {aiConfig.status === "ready" && aiConfig.mode === "mock" ? (
+        <div
+          role="status"
+          className="mb-6 rounded-xl border border-amber-500/25 bg-amber-500/10 px-4 py-3 text-base text-amber-100/95"
+        >
+          <span className="font-medium text-amber-200">Mock AI</span>
+          {" — "}
+          No model credits used. Server mode comes from{" "}
+          <code className="rounded bg-black/30 px-1.5 py-0.5 text-sm text-zinc-200">
+            SCRUMIQ_AI_MODE
+          </code>{" "}
+          in{" "}
+          <code className="rounded bg-black/30 px-1.5 py-0.5 text-sm text-zinc-200">
+            .env.local
+          </code>
+          .
+        </div>
+      ) : null}
+      {aiConfig.status === "ready" && aiConfig.mode === "live" ? (
+        <div
+          role="status"
+          className="mb-6 rounded-xl border border-sky-500/25 bg-sky-500/10 px-4 py-3 text-base text-sky-100/95"
+        >
+          <span className="font-medium text-sky-200">Live AI</span>
+          {" — "}
+          Backlog generation is not wired to the model yet. Use{" "}
+          <code className="rounded bg-black/30 px-1.5 py-0.5 text-sm text-zinc-200">
+            SCRUMIQ_AI_MODE=mock
+          </code>{" "}
+          for local mock data until{" "}
+          <code className="rounded bg-black/30 px-1.5 py-0.5 text-sm text-zinc-200">
+            POST /api/projects/ai-backlog
+          </code>{" "}
+          exists.
+        </div>
+      ) : null}
+      {aiConfig.status === "error" ? (
+        <div
+          role="alert"
+          className="mb-6 rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-base text-red-100"
+        >
+          {aiConfig.error} Refresh the page.
+        </div>
+      ) : null}
       <div className="mb-6 flex flex-wrap items-center gap-3">
         <Link
           href={`/projects/${projectId}`}
@@ -327,10 +387,20 @@ export function ProjectAiFlowView({
             </button>
             <button
               type="submit"
-              className="rounded-xl px-10 py-3.5 text-base font-semibold text-[var(--background)] transition-opacity hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-accent)]/50"
+              disabled={
+                aiConfig.status === "loading" || aiConfig.status === "error"
+              }
+              title={
+                aiConfig.status === "loading"
+                  ? "Loading AI settings…"
+                  : aiConfig.status === "error"
+                    ? "Fix AI config loading error first"
+                    : undefined
+              }
+              className="rounded-xl px-10 py-3.5 text-base font-semibold text-[var(--background)] transition-opacity hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-accent)]/50 disabled:cursor-not-allowed disabled:opacity-50"
               style={{ background: "var(--app-accent)" }}
             >
-              Generate
+              {aiConfig.status === "loading" ? "Loading…" : "Generate"}
             </button>
           </div>
         </form>

--- a/docs/AI-BRIEF-AND-BACKLOG-GENERATION-FLOW.md
+++ b/docs/AI-BRIEF-AND-BACKLOG-GENERATION-FLOW.md
@@ -11,7 +11,7 @@ This document describes the **current end-to-end flow**: structured **project co
 ## End-to-end user flow (as implemented)
 
 1. **Structured input** — User fills fields aligned with `ProjectAiBriefInput` (`lib/projects/ai-brief-types.ts`), validates, and submits.
-2. **Generating** — One full-area loading state while **backlog artifacts** are produced. Today this uses **`buildStubBacklogDraftFromInput`** in `lib/projects/ai-backlog-stub.ts` (no API key, no `POST /api/projects/ai-brief` in this flow).
+2. **Generating** — One full-area loading state while **backlog artifacts** are produced. The UI loads **`GET /api/ai-config`** so **`SCRUMIQ_AI_MODE`** (in `.env.local` only) drives mock vs live without a duplicate public env var. In **mock** mode (default), **`buildStubBacklogDraftFromInput`** in `lib/projects/ai-backlog-stub.ts` runs (no API key, no `POST /api/projects/ai-brief` in this flow). **Live** mode shows a notice and blocks generation until a live backlog API exists.
 3. **Artifact review** — User inspects epics → stories → acceptance criteria → tasks (`AiBacklogDraftPayload` in `ai-backlog-draft-types.ts`).
 4. **Add to backlog** — Saves the draft to **session storage** and navigates to **`/projects/[id]/backlog`**. Engagement is marked **`complete`**.
 5. **Backlog page** — Reads the session draft and lists items.

--- a/docs/PLANNED-AI-BRIEF-MOCK-RESTORE.md
+++ b/docs/PLANNED-AI-BRIEF-MOCK-RESTORE.md
@@ -10,7 +10,7 @@ The **main backlog flow** on **`/projects/[id]/brief`** generates artifacts via 
 
 ## Environment
 
-- **`SCRUMIQ_AI_MODE`** — unset or `mock` → use `buildMockAiBrief`. `live` → implement provider (today returns **501** until wired).
+- **`SCRUMIQ_AI_MODE`** — unset or `mock` → use `buildMockAiBrief`. `live` → implement provider (today returns **501** until wired). The app reads the same variable on the client via **`GET /api/ai-config`** (no `NEXT_PUBLIC_*` duplicate).
 
 ## Types (`lib/projects/ai-brief-types.ts`)
 

--- a/docs/PROJECTS-WORKSPACE.md
+++ b/docs/PROJECTS-WORKSPACE.md
@@ -47,10 +47,12 @@ They can own **`app/api/projects/ai-brief/route.ts`**, **`lib/projects/ai-brief-
 | File | Role |
 |------|------|
 | `app/(app)/projects/[id]/brief/page.tsx` | AI brief → backlog draft flow (form, review, stub backlog). |
-| `components/projects/ai-flow/ProjectAiFlowView.tsx` | Form → generate → review; backlog from `buildStubBacklogDraftFromInput` (no brief API in this flow). |
+| `components/projects/ai-flow/ProjectAiFlowView.tsx` | Form → generate → review; uses `GET /api/ai-config`; mock mode uses `buildStubBacklogDraftFromInput` (no brief API in this flow). |
 | `ProjectBacklogView.tsx` | Reads session draft from `backlog-draft-storage.ts`. |
 | `ProjectAiBriefModal.tsx` | Legacy explainer modal (unused; flow lives on `/brief`). |
 | `ProjectWorkspaceView.tsx` | `pending` → `router.replace` to `/brief`; link back to flow when dismissed/complete. |
 | `CreateProjectModal.tsx` | Sets `aiBriefEngagement: "pending"` on new projects. |
-| `app/api/projects/ai-brief/route.ts` | Mock/live brief API (used by flow). |
+| `app/api/ai-config/route.ts` | Exposes `SCRUMIQ_AI_MODE` to the client (`GET`). |
+| `app/api/projects/ai-brief/route.ts` | Mock/live brief API (optional; not called by `/brief` backlog flow today). |
+| `hooks/use-ai-config.ts` | Client hook for `/api/ai-config`. |
 | `lib/projects/ai-brief-types.ts` | Brief request/response contract. |

--- a/hooks/use-ai-config.ts
+++ b/hooks/use-ai-config.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ScrumiqAiMode } from "@/lib/projects/ai-mode";
+
+type AiConfigState =
+  | { status: "loading"; mode: null; error: null }
+  | { status: "ready"; mode: ScrumiqAiMode; error: null }
+  | { status: "error"; mode: null; error: string };
+
+/**
+ * Reads server `SCRUMIQ_AI_MODE` via `GET /api/ai-config` (single env var in `.env.local`).
+ */
+export function useAiConfig(): AiConfigState {
+  const [state, setState] = useState<AiConfigState>({
+    status: "loading",
+    mode: null,
+    error: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/ai-config");
+        if (!res.ok) {
+          throw new Error(`Request failed (${res.status})`);
+        }
+        const data = (await res.json()) as { mode?: unknown };
+        if (cancelled) return;
+        const mode =
+          data.mode === "live" || data.mode === "mock" ? data.mode : "mock";
+        setState({ status: "ready", mode, error: null });
+      } catch {
+        if (!cancelled) {
+          setState({
+            status: "error",
+            mode: null,
+            error: "Couldn’t read AI mode from the server.",
+          });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return state;
+}

--- a/lib/projects/ai-mode.ts
+++ b/lib/projects/ai-mode.ts
@@ -1,0 +1,18 @@
+/**
+ * Parsing helpers for `SCRUMIQ_AI_MODE` (read `process.env` only on the server).
+ * Types are safe to import in client code; call `parseScrumiqAiMode` on the server
+ * or use `GET /api/ai-config` in the browser.
+ */
+export type ScrumiqAiMode = "mock" | "live";
+
+export function parseScrumiqAiMode(
+  raw: string | undefined
+): ScrumiqAiMode {
+  const m = raw?.toLowerCase().trim();
+  if (m === "live") return "live";
+  return "mock";
+}
+
+export function isMockAiMode(raw: string | undefined): boolean {
+  return parseScrumiqAiMode(raw) === "mock";
+}


### PR DESCRIPTION
- Added `GET /api/ai-config` endpoint to expose `SCRUMIQ_AI_MODE` to the client.
- Created `useAiConfig` hook to manage AI mode state in the client.
- Updated components and documentation to reflect changes in AI mode handling.
- Improved user feedback for AI settings status in the UI.